### PR TITLE
[GP-32783] Add support for php 8.2 and above

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.2 ##
+* Add support for php 8.2 (and above)
+
 ## 5.0.1 ##
 * Replace `strftime()` with `date()` to avoid deprecation warnings
 

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
         }
     ],
     "require": {
-        "php": ">=8.0 <8.2",
-        "innogames/php-resque": "^5.0",
+        "php": ">=8.1",
+        "innogames/php-resque": "^5.1",
         "psr/log": "^1.1",
         "ext-pcntl": "*",
         "ext-json": "*"

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "innogames/php-resque": "^5.1",
+        "innogames/php-resque": "^5.0.2",
         "psr/log": "^1.1",
         "ext-pcntl": "*",
         "ext-json": "*"


### PR DESCRIPTION
PR in resque repo needs to be merged and new version released first, since we need it here